### PR TITLE
Add .spi.yml for Swift Package Index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,13 @@
+version: 1
+
+builder:
+  configs:
+    - documentation_targets: [MediaBridge]
+      swift_version: 6.0
+
+previewReleases: []
+
+generationParameters:
+  minimumSwiftVersion: 6.0
+  minPlatformVersions:
+    iOS: "15.0"


### PR DESCRIPTION
## Summary
- Added .spi.yml configuration for Swift Package Index
- Configured documentation generation for MediaBridge target
- Set Swift 6.0 as minimum version
- Set iOS 15.0 as minimum platform version

## Test Plan
- [x] Configuration syntax is valid YAML

Closes #18