### PR TITLE
Add debug preview mocks for MusicLibraryProtocol

### DIFF
--- a/Example/MediaBridgeSample/ContentView.swift
+++ b/Example/MediaBridgeSample/ContentView.swift
@@ -71,3 +71,8 @@ extension SortOrder {
         self = self == .forward ? .reverse : .forward
     }
 }
+
+#Preview {
+    ContentView()
+        .environment(\.library, .accessDenied)
+}

--- a/Sources/Utils/Preview/MusicLibraryProtocol+preview.swift
+++ b/Sources/Utils/Preview/MusicLibraryProtocol+preview.swift
@@ -1,0 +1,40 @@
+import Foundation
+import MediaPlayer
+
+#if DEBUG
+    extension MusicLibraryProtocol where Self == PreviewMusicLibrary {
+        public static var accessDenied: PreviewMusicLibrary { .preview(authStatus: .denied) }
+        public static var accessRestricted: PreviewMusicLibrary { .preview(authStatus: .restricted) }
+        public static var accessNotDetermined: PreviewMusicLibrary { .preview(authStatus: .notDetermined) }
+        public static var accessAuthorized: PreviewMusicLibrary { .preview() }
+
+        public static var accessDeniedAfterRequest: PreviewMusicLibrary {
+            .preview(authStatus: .denied, authStatusAfterRequest: .denied)
+        }
+        public static var accessRestrictedAfterRequest: PreviewMusicLibrary {
+            .preview(authStatus: .denied, authStatusAfterRequest: .restricted)
+        }
+        public static var accessNotDeterminedAfterRequest: PreviewMusicLibrary {
+            .preview(authStatus: .denied, authStatusAfterRequest: .notDetermined)
+        }
+        public static var accessAuthorizedAfterRequest: PreviewMusicLibrary { .preview(authStatus: .denied) }
+
+        public static func preview(
+            authStatus: MPMediaLibraryAuthorizationStatus = .authorized,
+            authStatusAfterRequest: MPMediaLibraryAuthorizationStatus = .authorized,
+            fetchedAllMedia: [MPMediaItem] = [],
+            fetchedMedia: [MPMediaItem] = [],
+            fetchedSongs: [MPMediaItem] = [],
+            filteredSongs: [MPMediaItem] = []
+        ) -> PreviewMusicLibrary {
+            PreviewMusicLibrary(
+                status: authStatus,
+                statusAfterRequest: authStatusAfterRequest,
+                fetchedAllMedia: fetchedAllMedia,
+                fetchedMedia: fetchedMedia,
+                fetchedSongs: fetchedSongs,
+                filteredSongs: filteredSongs
+            )
+        }
+    }
+#endif

--- a/Sources/Utils/Preview/PreviewMusicLibrary.swift
+++ b/Sources/Utils/Preview/PreviewMusicLibrary.swift
@@ -1,0 +1,46 @@
+import Foundation
+import MediaPlayer
+
+#if DEBUG
+    public class PreviewMusicLibrary: MusicLibraryProtocol {
+        private let status: MPMediaLibraryAuthorizationStatus
+        private let statusAfterRequest: MPMediaLibraryAuthorizationStatus
+        private let fetchedAllMedia: [MPMediaItem]
+        private let fetchedMedia: [MPMediaItem]
+        private let fetchedSongs: [MPMediaItem]
+        private let filteredSongs: [MPMediaItem]
+
+
+        init(
+            status: MPMediaLibraryAuthorizationStatus,
+            statusAfterRequest: MPMediaLibraryAuthorizationStatus,
+            fetchedAllMedia: [MPMediaItem],
+            fetchedMedia: [MPMediaItem],
+            fetchedSongs: [MPMediaItem],
+            filteredSongs: [MPMediaItem]
+        ) {
+            self.status = status
+            self.statusAfterRequest = statusAfterRequest
+            self.fetchedAllMedia = fetchedAllMedia
+            self.fetchedMedia = fetchedMedia
+            self.fetchedSongs = fetchedSongs
+            self.filteredSongs = filteredSongs
+        }
+
+        public var authorizationStatus: MPMediaLibraryAuthorizationStatus { status }
+        public func requestAuthorization() async throws -> MPMediaLibraryAuthorizationStatus { statusAfterRequest }
+        public func fetchAll(_ type: MPMediaType, groupingType: MPMediaGrouping) async throws -> [MPMediaItem] { fetchedAllMedia }
+        public func fetch(
+            _ type: MPMediaType,
+            with predicate: MediaBridge.MediaItemPredicateInfo,
+            _ comparisonType: MPMediaPredicateComparison,
+            groupingType: MPMediaGrouping
+        ) async throws -> [MPMediaItem] { fetchedMedia }
+        public func fetchSongs<T>(sortedBy sortingKey: (any KeyPath<MPMediaItem, T> & Sendable)?, order: SortOrder) async throws
+            -> [MPMediaItem]
+        where T: Comparable { fetchedSongs }
+        public func fetchSong(with predicate: MediaBridge.MediaItemPredicateInfo, comparisonType: MPMediaPredicateComparison) async throws
+            -> [MPMediaItem]
+        { filteredSongs }
+    }
+#endif


### PR DESCRIPTION
Add debug preview mocks for MusicLibraryProtocol to enable testing and development without real library implementations.

Closes #32